### PR TITLE
Don't autofocus on load

### DIFF
--- a/src/editor.vue
+++ b/src/editor.vue
@@ -86,7 +86,7 @@
 
           // Set editor content
           if (this.value || this.content) {
-            this.quill.pasteHTML(this.value || this.content)
+            this.quill.setContents(this.quill.clipboard.convert(this.value || this.content))
           }
 
           // Disabled editor


### PR DESCRIPTION
If the editor has content upon initial load it will gain focus, which can cause unexpected page scrolling.
This is because of using `.pasteHTML()` (which is just a wrapper around `.clipboard.dangerouslyPasteHTML()`) - doing it this way fixes the issue with autofocus.
(Incidentally, credit for the fix goes to @jetzhou - see zenoamaro/react-quill#321)